### PR TITLE
テーマカラーの変更

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -78,9 +78,9 @@ export default {
           error: '#FF5252'
         },
         light: {
-          primary: '#FB86C1',
-          accent: '#BC78C8',
-          secondary: '#31ACD6',
+          primary: '#EC6D81',
+          accent: '#3578AF',
+          secondary: '#B365A7',
           success: '#78E07D',
           info: '#84C6FA',
           warning: '#D8E704',


### PR DESCRIPTION
fix #14 

## 変更内容
- primaryカラーをクライアントが指定する色に変更
トーンがずれないようにaccentやsecondaryも合わせて変更

- accentとsecondaryの色を逆転させた
accentを目立たせたいため。変更前はprimaryとsecondaryが補色になっていた。