### PR TITLE
bugfix:ログインフォーム上で会社番号を入力してもvuexのclientIdに反映されない

### DIFF
--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -45,6 +45,10 @@ export default class LoginVue extends Vue {
     return LoginStore.clientId
   }
 
+  set clientId(clientId) {
+    LoginStore.setClientId(clientId)
+  }
+
   get emailLoginUrl(): string {
     return `${this.apiDomain}/api/login/${this.clientId}/email`
   }


### PR DESCRIPTION
たまたまバグを見つけたので修正しておきました。
周辺コードを参考にしました。

ご確認をよろしくお願いいたします。