### PR TITLE
モックに社員管理画面を追加

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -25,9 +25,24 @@
       <v-spacer></v-spacer>
       <v-spacer></v-spacer>
       <div v-if="isLoggedIn" class="d-flex align-center">
-        <v-btn icon>
-          <v-icon>mdi-settings</v-icon>
-        </v-btn>
+        <div class="text-center">
+          <v-menu offset-y>
+            <template v-slot:activator="{ on }">
+              <v-btn icon v-on="on">
+                <v-icon>mdi-settings</v-icon>
+              </v-btn>
+            </template>
+            <v-list>
+              <v-list-item
+                v-for="(item, index) in settings"
+                :key="index"
+                :to="item.link"
+              >
+                <v-list-item-title>{{ item.title }}</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+        </div>
         <v-btn icon>
           <v-icon>mdi-bell</v-icon>
         </v-btn>
@@ -74,6 +89,11 @@ export default class DefaultLayout extends Vue {
           text: 'その他公報',
           link: '/gazettes'
         }
+      ],
+      settings: [
+        { title: '社員管理', link: '/employees' },
+        { title: 'LINE設定', link: '/lines' },
+        { title: 'パスワード変更', link: '/password' }
       ]
     }
   }

--- a/mock/employees/index.vue
+++ b/mock/employees/index.vue
@@ -9,8 +9,10 @@
             :items="employees"
             class="elevation-1"
           >
-            <template v-slot:item.edit="{ item }">
-              <v-btn outlined small color="secondary">{{ item.edit }}</v-btn>
+            <template v-slot:item.toggleValid="{ item }">
+              <v-btn outlined small color="secondary">{{
+                item.toggleValid
+              }}</v-btn>
             </template>
             <template v-slot:item.others="{ item }">
               <v-menu top offset-y>
@@ -60,8 +62,7 @@ export default {
         { text: '権限', value: 'role' },
         { text: '登録日', value: 'created_at' },
         { text: '更新日', value: 'updated_at' },
-        { text: '', value: 'edit' },
-        { text: '', value: 'others' }
+        { text: '', value: 'toggleValid' }
       ],
       employees: [
         {
@@ -71,8 +72,52 @@ export default {
           role: '人事担当者',
           created_at: '2019/12/05 12:00:00',
           updated_at: '2019/12/05 12:00:00',
-          edit: '編集',
-          others: '・・・'
+          toggleValid: '-'
+        },
+        {
+          no: 2,
+          name: '布村',
+          status: '有効',
+          role: '社員',
+          created_at: '2019/12/05 12:00:00',
+          updated_at: '2019/12/05 12:00:00',
+          toggleValid: '無効にする'
+        },
+        {
+          no: 3,
+          name: 'だいすけ',
+          status: '無効',
+          role: '社員',
+          created_at: '2019/12/05 12:00:00',
+          updated_at: '2019/12/05 12:00:00',
+          toggleValid: '有効にする'
+        },
+        {
+          no: 4,
+          name: 'ごとう',
+          status: '無効',
+          role: '社員',
+          created_at: '2019/12/05 12:00:00',
+          updated_at: '2019/12/05 12:00:00',
+          toggleValid: '有効にする'
+        },
+        {
+          no: 5,
+          name: 'さとう',
+          status: '無効',
+          role: '社員',
+          created_at: '2019/12/05 12:00:00',
+          updated_at: '2019/12/05 12:00:00',
+          toggleValid: '有効にする'
+        },
+        {
+          no: 6,
+          name: 'ふじわら',
+          status: '無効',
+          role: '社員',
+          created_at: '2019/12/05 12:00:00',
+          updated_at: '2019/12/05 12:00:00',
+          toggleValid: '有効にする'
         }
       ]
     }

--- a/mock/employees/index.vue
+++ b/mock/employees/index.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <v-container>
+      <h2>社員一覧</h2>
+      <v-row justify="center">
+        <v-col :lg="9">
+          <v-data-table
+            :headers="headers"
+            :items="employees"
+            class="elevation-1"
+          >
+            <template v-slot:item.edit="{ item }">
+              <v-btn outlined small color="secondary">{{ item.edit }}</v-btn>
+            </template>
+            <template v-slot:item.others="{ item }">
+              <v-menu top offset-y>
+                <template v-slot:activator="{ on }">
+                  <v-btn color="secondary" small outlined v-on="on">
+                    {{ item.others }}
+                  </v-btn>
+                </template>
+                <v-list>
+                  <v-list-item
+                    v-for="(listitem, index) in listitems"
+                    :key="index"
+                    :to="listitem.link"
+                  >
+                    <v-list-item-title>{{ listitem.title }}</v-list-item-title>
+                  </v-list-item>
+                </v-list>
+              </v-menu>
+            </template>
+          </v-data-table>
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      listitems: [
+        {
+          title: 'LINEでシェア',
+          link: '/jobs/shares/create'
+        },
+        { title: '下書きに戻す' },
+        { title: '削除' }
+      ],
+      dialog: false,
+      headers: [
+        {
+          text: 'No',
+          align: 'left',
+          value: 'no'
+        },
+        { text: '名前', value: 'name' },
+        { text: 'ステータス', value: 'status' },
+        { text: '権限', value: 'role' },
+        { text: '登録日', value: 'created_at' },
+        { text: '更新日', value: 'updated_at' },
+        { text: '', value: 'edit' },
+        { text: '', value: 'others' }
+      ],
+      employees: [
+        {
+          no: 1,
+          name: '會田 朋也',
+          status: '有効',
+          role: '人事担当者',
+          created_at: '2019/12/05 12:00:00',
+          updated_at: '2019/12/05 12:00:00',
+          edit: '編集',
+          others: '・・・'
+        }
+      ]
+    }
+  }
+}
+</script>

--- a/mock/employees/index.vue
+++ b/mock/employees/index.vue
@@ -14,23 +14,8 @@
                 item.toggleValid
               }}</v-btn>
             </template>
-            <template v-slot:item.others="{ item }">
-              <v-menu top offset-y>
-                <template v-slot:activator="{ on }">
-                  <v-btn color="secondary" small outlined v-on="on">
-                    {{ item.others }}
-                  </v-btn>
-                </template>
-                <v-list>
-                  <v-list-item
-                    v-for="(listitem, index) in listitems"
-                    :key="index"
-                    :to="listitem.link"
-                  >
-                    <v-list-item-title>{{ listitem.title }}</v-list-item-title>
-                  </v-list-item>
-                </v-list>
-              </v-menu>
+            <template v-slot:item.image="{ item }">
+              <v-img :src="item.image" aspect-ratio="2" contain></v-img>
             </template>
           </v-data-table>
         </v-col>
@@ -42,15 +27,6 @@
 export default {
   data() {
     return {
-      listitems: [
-        {
-          title: 'LINEでシェア',
-          link: '/jobs/shares/create'
-        },
-        { title: '下書きに戻す' },
-        { title: '削除' }
-      ],
-      dialog: false,
       headers: [
         {
           text: 'No',
@@ -58,6 +34,7 @@ export default {
           value: 'no'
         },
         { text: '名前', value: 'name' },
+        { text: 'アイコン', value: 'image' },
         { text: 'ステータス', value: 'status' },
         { text: '権限', value: 'role' },
         { text: '登録日', value: 'created_at' },
@@ -68,6 +45,7 @@ export default {
         {
           no: 1,
           name: '會田 朋也',
+          image: 'https://picsum.photos/510/300?random',
           status: '有効',
           role: '人事担当者',
           created_at: '2019/12/05 12:00:00',
@@ -77,6 +55,7 @@ export default {
         {
           no: 2,
           name: '布村',
+          image: 'https://picsum.photos/510/300?random',
           status: '有効',
           role: '社員',
           created_at: '2019/12/05 12:00:00',
@@ -86,6 +65,7 @@ export default {
         {
           no: 3,
           name: 'だいすけ',
+          image: 'https://picsum.photos/510/300?random',
           status: '無効',
           role: '社員',
           created_at: '2019/12/05 12:00:00',
@@ -95,6 +75,7 @@ export default {
         {
           no: 4,
           name: 'ごとう',
+          image: 'https://picsum.photos/510/300?random',
           status: '無効',
           role: '社員',
           created_at: '2019/12/05 12:00:00',
@@ -104,6 +85,7 @@ export default {
         {
           no: 5,
           name: 'さとう',
+          image: 'https://picsum.photos/510/300?random',
           status: '無効',
           role: '社員',
           created_at: '2019/12/05 12:00:00',
@@ -113,6 +95,7 @@ export default {
         {
           no: 6,
           name: 'ふじわら',
+          image: 'https://picsum.photos/510/300?random',
           status: '無効',
           role: '社員',
           created_at: '2019/12/05 12:00:00',

--- a/mock/employees/index.vue
+++ b/mock/employees/index.vue
@@ -10,7 +10,7 @@
             class="elevation-1"
           >
             <template v-slot:item.toggleValid="{ item }">
-              <v-btn outlined small color="secondary">{{
+              <v-btn outlined small :color="getColor(item.status)">{{
                 item.toggleValid
               }}</v-btn>
             </template>
@@ -117,6 +117,12 @@ export default {
           toggleValid: '有効にする'
         }
       ]
+    }
+  },
+  methods: {
+    getColor(status) {
+      if (status === '有効') return 'secoundary'
+      else return 'primary'
     }
   }
 }

--- a/mock/employees/index.vue
+++ b/mock/employees/index.vue
@@ -3,7 +3,7 @@
     <v-container>
       <h2>社員一覧</h2>
       <v-row justify="center">
-        <v-col :lg="9">
+        <v-col>
           <v-data-table
             :headers="headers"
             :items="employees"
@@ -35,6 +35,8 @@ export default {
         },
         { text: '名前', value: 'name' },
         { text: 'アイコン', value: 'image' },
+        { text: 'メッセージ', value: 'message' },
+        { text: 'ユーザーID', value: 'userId' },
         { text: 'ステータス', value: 'status' },
         { text: '権限', value: 'role' },
         { text: '登録日', value: 'created_at' },
@@ -46,6 +48,8 @@ export default {
           no: 1,
           name: '會田 朋也',
           image: 'https://picsum.photos/510/300?random',
+          message: 'こんにちは',
+          userId: '123456789',
           status: '有効',
           role: '人事担当者',
           created_at: '2019/12/05 12:00:00',
@@ -56,6 +60,8 @@ export default {
           no: 2,
           name: '布村',
           image: 'https://picsum.photos/510/300?random',
+          message: 'こんにちは',
+          userId: '123456789',
           status: '有効',
           role: '社員',
           created_at: '2019/12/05 12:00:00',
@@ -66,6 +72,8 @@ export default {
           no: 3,
           name: 'だいすけ',
           image: 'https://picsum.photos/510/300?random',
+          message: 'こんにちは',
+          userId: '123456789',
           status: '無効',
           role: '社員',
           created_at: '2019/12/05 12:00:00',
@@ -76,6 +84,8 @@ export default {
           no: 4,
           name: 'ごとう',
           image: 'https://picsum.photos/510/300?random',
+          message: 'こんにちは',
+          userId: '123456789',
           status: '無効',
           role: '社員',
           created_at: '2019/12/05 12:00:00',
@@ -86,6 +96,8 @@ export default {
           no: 5,
           name: 'さとう',
           image: 'https://picsum.photos/510/300?random',
+          message: 'こんにちは',
+          userId: '123456789',
           status: '無効',
           role: '社員',
           created_at: '2019/12/05 12:00:00',
@@ -96,6 +108,8 @@ export default {
           no: 6,
           name: 'ふじわら',
           image: 'https://picsum.photos/510/300?random',
+          message: 'こんにちは',
+          userId: '123456789',
           status: '無効',
           role: '社員',
           created_at: '2019/12/05 12:00:00',

--- a/mock/employees/index.vue
+++ b/mock/employees/index.vue
@@ -37,10 +37,10 @@ export default {
         { text: 'アイコン', value: 'image' },
         { text: 'メッセージ', value: 'message' },
         { text: 'ユーザーID', value: 'userId' },
-        { text: 'ステータス', value: 'status' },
         { text: '権限', value: 'role' },
         { text: '登録日', value: 'created_at' },
         { text: '更新日', value: 'updated_at' },
+        { text: 'ステータス', value: 'status' },
         { text: '', value: 'toggleValid' }
       ],
       employees: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,5 +34,10 @@
   },
   "exclude": [
     "node_modules"
-  ]
+  ],
+  "rules": {
+    "no-console": [
+      false
+    ]
+  }
 }


### PR DESCRIPTION
# 概要
モックに社員管理画面を追加

## 対応内容
モックに以下の対応をした
- トップページ右上の設定ボタンを押すと、設定メニューを開く
-  設定メニューから「社員管理」ボタンを押すと、社員管理画面を開く
   - その他のメニューボタンは未実装

