### PR TITLE
各種トークンをセッションに保持する

### DIFF
--- a/middleware/is-logged-in.ts
+++ b/middleware/is-logged-in.ts
@@ -6,7 +6,10 @@ const isLoggedIn: Middleware = (context: Context) => {
   // 本来はアクセストークンを設定せず、モックの時だけisLoggedInの戻り値をTRUEにしたい。
   // しかし、envがisLoggedIn内で参照できないので、暫定的にアクセストークンを設定している
   if (env.isMock) {
-    loginStore.setAccessToken('dummy_token');
+    loginStore.setAccessToken({ 
+      accessToken: 'dummy_token',
+      refreshToken: 'dummy_token'
+    });
     return
   }
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,7 +33,7 @@ export default {
   /*
    ** Plugins to load before mounting the App
    */
-  plugins: [],
+  plugins: [{ src: '@/plugins/persisted-state.js', ssr: false }],
   /*
    ** Nuxt.js dev-modules
    */

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "audit": "^0.0.6",
     "axios": "^0.19.0",
     "nuxt": "^2.11.0",
-    "nuxt-property-decorator": "^2.5.0"
+    "nuxt-property-decorator": "^2.5.0",
+    "vuex-persistedstate": "^2.7.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.5.5",

--- a/plugins/persisted-state.js
+++ b/plugins/persisted-state.js
@@ -1,0 +1,11 @@
+import createPersistedState from 'vuex-persistedstate'
+
+export default ({ store }) => {
+  window.onNuxtReady(() => {
+    const createPersistedStateFunction = createPersistedState({
+      storage: window.sessionStorage,
+      path: ['login.accessToken', 'login.clientId']
+    })
+    createPersistedStateFunction(store)
+  })
+}

--- a/store/login.ts
+++ b/store/login.ts
@@ -7,6 +7,11 @@ interface apiClientData {
   secret: string
 }
 
+interface loginToken {
+  accessToken: string
+  refreshToken: string
+}
+
 export interface LoginState {
   clientId: string
   accessToken: string
@@ -16,6 +21,7 @@ export interface LoginState {
 @Module({ stateFactory: true, namespaced: true, name: 'login' })
 export default class Login extends VuexModule implements LoginState {
   accessToken: string = ''
+  refreshToken: string = ''
   clientId: string = ''
   apiClientData: apiClientData|null = null
 
@@ -47,8 +53,9 @@ export default class Login extends VuexModule implements LoginState {
   }
 
   @Mutation
-  setAccessToken( accessToken: string ) {
-    this.accessToken = accessToken
+  setAccessToken( token: loginToken ) {
+    this.accessToken = token.accessToken
+    this.refreshToken = token.refreshToken
   }
 
   @Action
@@ -57,7 +64,7 @@ export default class Login extends VuexModule implements LoginState {
     const response = await axios.post(loginPost.url, formData)
     const { data } = response
 
-    this.setAccessToken(data.access_token)
+    this.setAccessToken(data)
     return data.access_token
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10701,6 +10701,11 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+shvl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shvl/-/shvl-2.0.0.tgz#55fd550b6e81bf7574f2f576b8b5c1ffae74e10f"
+  integrity sha512-WbpzSvI5XgVGJ3A4ySGe8hBxj0JgJktfnoLhhJmvITDdK21WPVWwgG8GPlYEh4xqdti3Ff7PJ5G0QrRAjNS0Ig==
+
 sigmund@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
@@ -12090,6 +12095,14 @@ vuex-module-decorators@^0.10.1:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/vuex-module-decorators/-/vuex-module-decorators-0.10.1.tgz#a34ebf7c2aec701d19ae60dea0a8f1620825fd9e"
   integrity sha512-OBvHEeer8uT///oTWqgf7kPe0j3hb9IC9ahdk41S4gBHhn5YUHpyXdry2OXp77zPzQ1P6wTY+Ju+/VUcU5mhzA==
+
+vuex-persistedstate@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-2.7.0.tgz#f60aae4e1163bf293696a625526dbffaa42e429e"
+  integrity sha512-mpko65DUMBY4mF4sSGsgrqjE7fwO373LFZeuNrC55glRuBBAK4dkgzjr4j4Bij7WtMoKuo2t2w0NGenjauISaQ==
+  dependencies:
+    deepmerge "^4.2.2"
+    shvl "^2.0.0"
 
 vuex@^3.1.1, vuex@^3.1.2:
   version "3.1.2"


### PR DESCRIPTION
# 概要
- #21 の続き

## 対応内容
- vuex-storage-persitedの追加
- リフレッシュトークンを保持する
- セッションに保持させるように修正
    - ローカルストレージは同意形式になったはず
    - 将来的に、「ログイン情報を保持する」のようなチェックボックスで、記録させる