### PR TITLE
apolloの初期設定を実装

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     node: true
   },
   parserOptions: {
-    parser: 'babel-eslint',
+    parser: '@typescript-eslint/parser',
     ecmaFeatures: {
       legacyDecorators: true
     }

--- a/apollo/queries/GetUsers.gql
+++ b/apollo/queries/GetUsers.gql
@@ -1,0 +1,6 @@
+query GetUsers {
+  users {
+    id
+    name
+  }
+}

--- a/components/login/email-login-form.vue
+++ b/components/login/email-login-form.vue
@@ -21,6 +21,10 @@ export default class EmailLoginForm extends Vue {
     await loginStore.postEmailLogin(
       new EmailLoginPost(this.loginUrl, this.email, this.password)
     )
+
+    if (loginStore.isLoggedIn) {
+      this.$router.push('index')
+    }
   }
 }
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -61,7 +61,7 @@
 import { Component, Vue } from 'vue-property-decorator'
 import { loginStore } from '@/store'
 
-@Component
+@Component({ middleware: ['fetch-client-id'] })
 export default class DefaultLayout extends Vue {
   get isLoggedIn(): boolean {
     return loginStore.isLoggedIn

--- a/middleware/fetch-client-id.ts
+++ b/middleware/fetch-client-id.ts
@@ -1,8 +1,27 @@
 import { Context, Middleware } from '@nuxt/types'
+import { loginStore } from '@/store'
 
-const fetchCliendId: Middleware = ({ store, query }: Context) => {
-  const clientId: string = query.client_id as string
-  store.commit('login/setClientId', clientId)
+const fetchCliendId: Middleware = (context: Context) => {
+  const { app, query, route, redirect } = context
+  // クライアントIDが存在しない場合は処理なし
+  if (!('client_id' in query && typeof query.client_id === 'string')) {
+    return
+  }
+
+  // 全く同一の場合は処理なし
+  if ( loginStore.clientId === query.client_id) {
+    return
+  }
+
+  // ログイン画面もしくは、空の場合のみ、セットする
+  if (loginStore.clientId === '' ||　String(route.name).startsWith('login')) {
+    loginStore.setClientId(query.client_id)
+    return
+  }
+
+  // 異なるクライアントIDの場合は不正アクセスなので、ログイン画面に飛ばす
+  loginStore.logout()
+  redirect('/login')
 }
 
 export default fetchCliendId

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,7 +4,7 @@ const environment = process.env.NODE_ENV || 'development'
 const envValues = getConfig(environment)
 
 export default {
-  mode: 'universal',
+  mode: 'spa',
   /*
    ** Headers of the page
    */
@@ -52,7 +52,8 @@ export default {
       default: {
         httpEndpoint: `${envValues.apiDomain}/graphql`
       }
-    }
+    },
+    errorHandler: '@/plugins/apollo/error-handler.js'
   },
 
   axios: {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nuxtjs/pwa": "^3.0.0-0",
     "@types/form-data": "^2.5.0",
     "@types/node-fetch": "^2.5.4",
+    "@typescript-eslint/parser": "^2.13.0",
     "audit": "^0.0.6",
     "axios": "^0.19.0",
     "nuxt": "^2.11.0",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,3 +5,20 @@
     </v-flex>
   </v-layout>
 </template>
+
+<script lang="ts">
+import { Vue, Component } from 'nuxt-property-decorator'
+
+// 以下、テスト用。クエリ内容的に、gql関数を使った方がよさそう
+//  詳細は、ライブラリgraphql-tagを確認すること
+const getUsers = require('@/apollo/queries/GetUsers.gql')
+
+@Component({
+  apollo: {
+    users: {
+      query: getUsers
+    }
+  }
+} as any)
+export default class IndexVue extends Vue {}
+</script>

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -24,14 +24,14 @@
 
 <script lang="ts">
 import { Vue, Component } from 'nuxt-property-decorator'
-import { Context } from '@nuxt/types'
+import { Context } from '@nuxt/types' // eslint-disable-line no-unused-vars
 import { loginStore } from '@/store'
 import EmailLoginForm from '@/components/login/email-login-form.vue'
 import LineLoginBtn from '@/components/login/line-login-btn.vue'
 
 @Component({
   components: { EmailLoginForm, LineLoginBtn },
-  middleware: ['fetch-client-id', 'initialize-form-data']
+  middleware: ['initialize-form-data']
 })
 export default class LoginVue extends Vue {
   asyncData({ env }: Context) {

--- a/pages/login/redirect.vue
+++ b/pages/login/redirect.vue
@@ -8,7 +8,7 @@
 
 <script lang="ts">
 import { Vue, Component } from 'nuxt-property-decorator'
-import { Context } from '@nuxt/types'
+import { Context } from '@nuxt/types' // eslint-disable-line no-unused-vars
 import { loginStore } from '@/store'
 import { SocialLoginPost } from '@/models/login-post'
 
@@ -32,8 +32,15 @@ export default class RedirectLoginVue extends Vue {
     return `${this.apiDomain}/api/login/${this.clientId}/${this.provider}`
   }
 
-  mounted() {
-    loginStore.postSocialLogin(new SocialLoginPost(this.loginUrl, this.code))
+  async mounted() {
+    // mounted後でなければ、formDataが取得できないため、以下に実装
+    await loginStore.postSocialLogin(
+      new SocialLoginPost(this.loginUrl, this.code)
+    )
+
+    if (loginStore.isLoggedIn) {
+      this.$router.push('index')
+    }
   }
 }
 </script>

--- a/plugins/apollo/error-handler.js
+++ b/plugins/apollo/error-handler.js
@@ -1,0 +1,6 @@
+/* eslint-disable no-console */
+// TODO: apolloのエラー処理方法を検討する
+export default (error, nuxtContext) => {
+  console.log('Global error handler')
+  console.error(error)
+}

--- a/plugins/persisted-state.js
+++ b/plugins/persisted-state.js
@@ -1,11 +1,8 @@
 import createPersistedState from 'vuex-persistedstate'
 
 export default ({ store }) => {
-  window.onNuxtReady(() => {
-    const createPersistedStateFunction = createPersistedState({
-      storage: window.sessionStorage,
-      path: ['login.accessToken', 'login.clientId']
-    })
-    createPersistedStateFunction(store)
-  })
+  createPersistedState({
+    store: window.sessionStorage,
+    path: ['login.accessToken', 'login.clientId']
+  })(store)
 }

--- a/store/login.ts
+++ b/store/login.ts
@@ -8,8 +8,8 @@ interface apiClientData {
 }
 
 interface loginToken {
-  accessToken: string
-  refreshToken: string
+  access_token: string
+  refresh_token: string
 }
 
 export interface LoginState {
@@ -54,8 +54,15 @@ export default class Login extends VuexModule implements LoginState {
 
   @Mutation
   setAccessToken( token: loginToken ) {
-    this.accessToken = token.accessToken
-    this.refreshToken = token.refreshToken
+    this.accessToken = token.access_token
+    this.refreshToken = token.refresh_token
+  }
+
+  @Mutation
+  logout() {
+    this.accessToken = ''
+    this.refreshToken = ''
+    this.clientId = ''
   }
 
   @Action

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,6 +1634,11 @@
   dependencies:
     "@types/express" "*"
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/etag@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@types/etag/-/etag-1.8.0.tgz#37f0b1f3ea46da7ae319bbedb607e375b4c99f7e"
@@ -1947,6 +1952,15 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
+"@typescript-eslint/experimental-utils@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.13.0.tgz#958614faa6f77599ee2b241740e0ea402482533d"
+  integrity sha512-+Hss3clwa6aNiC8ZjA45wEm4FutDV5HsVXPl/rDug1THq6gEtOYRGLqS3JlTk7mSnL5TbJz0LpEbzbPnKvY6sw==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.13.0"
+    eslint-scope "^5.0.0"
+
 "@typescript-eslint/experimental-utils@^1.13.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz#b08c60d780c0067de2fb44b04b432f540138301e"
@@ -1956,6 +1970,16 @@
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-scope "^4.0.0"
 
+"@typescript-eslint/parser@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.13.0.tgz#ea1ab394cf9ca17467e3da7f96eca9309f57c326"
+  integrity sha512-vbDeLr5QRJ1K7x5iRK8J9wuGwR9OVyd1zDAY9XFAQvAosHVjSVbDgkm328ayE6hx2QWVGhwvGaEhedcqAbfQcA==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.13.0"
+    "@typescript-eslint/typescript-estree" "2.13.0"
+    eslint-visitor-keys "^1.1.0"
+
 "@typescript-eslint/typescript-estree@1.13.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz#8140f17d0f60c03619798f1d628b8434913dc32e"
@@ -1963,6 +1987,19 @@
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
+
+"@typescript-eslint/typescript-estree@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.13.0.tgz#a2e746867da772c857c13853219fced10d2566bc"
+  integrity sha512-t21Mg5cc8T3ADEUGwDisHLIubgXKjuNRbkpzDMLb7/JMmgCe/gHM9FaaujokLey+gwTuLF5ndSQ7/EfQqrQx4g==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0":
   version "1.0.0"
@@ -11539,10 +11576,17 @@ ts-node@^8, ts-node@^8.4.1:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-tslib@^1, tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
## 概要
- apolloの初期設定を実装
    - onLoginとonLogoutをmiddleware内で実行
- middleware内のログインチェックが機能するように、spaに修正
    - 今後、待ち時間中は、画面全体にloadingを書ける想定
- eslintを最新化
- apolloの動作確認用に、gqlファイルなどを追加
- 各種、middlewareによるリダイレクトの実装