### PR TITLE
本番でも動作するように修正

### DIFF
--- a/.env.examaple
+++ b/.env.examaple
@@ -1,6 +1,3 @@
 # バックエンドAPIサーバで登録したid,secretを入力する
 API_CLIENT_ID=
 API_CLIENT_SECRET=
-
-# 求人票のドメイン名 ※ 末尾のスラッシュは不要
-JOB_BOARD_DOMAIN=

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,14 @@
+{
+  "projects": {
+    "default": "teammaker-270808"
+  },
+  "targets": {
+    "teammaker-270808": {
+      "hosting": {
+        "admin": [
+          "teammaker-admin"
+        ]
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ sw.*
 
 .history
 .vscode
+.firebase

--- a/components/announces/announce/announce-confirm.vue
+++ b/components/announces/announce/announce-confirm.vue
@@ -64,8 +64,8 @@ export default {
   }),
   computed: {
     sharedAnnounce() {
-      if (this.shareUrl) {
-        return `${this.announce}\n${this.shareUrl}`
+      if (this.announceUrl) {
+        return `${this.announce}\n${this.announceUrl}`
       }
 
       return this.announce
@@ -73,7 +73,7 @@ export default {
     dialog() {
       return this.announceResult !== ''
     },
-    ...mapGetters('announce', ['shareUrl'])
+    ...mapGetters('announce', ['announceUrl'])
   },
   methods: {
     changeBeforeStep() {

--- a/configs/config.development.js
+++ b/configs/config.development.js
@@ -1,3 +1,1 @@
-export const envValues = {
-  apiDomain: 'http://localhost:8888'
-}
+export const envValues = {}

--- a/configs/config.staging.js
+++ b/configs/config.staging.js
@@ -1,3 +1,4 @@
 export const envValues = {
-  apiDomain: 'http://localhost:8888'
+  apiDomain: 'https://team-maker-app-xkz5u66uea-an.a.run.app',
+  jobBoard: 'https://teammaker-job.web.app/'
 }

--- a/configs/get-config.js
+++ b/configs/get-config.js
@@ -2,9 +2,7 @@ require('dotenv').config()
 
 const nodeEnvValues = {
   apiClientId: process.env.API_CLIENT_ID || '',
-  apiClientSecret: process.env.API_CLIENT_SECRET || '',
-  testApiClientId: process.env.TEST_API_CLIENT_ID || '',
-  testApiClientSecret: process.env.TEST_API_CLIENT_SECRET || ''
+  apiClientSecret: process.env.API_CLIENT_SECRET || ''
 }
 
 // 以下がデフォルト値になる

--- a/configs/get-config.js
+++ b/configs/get-config.js
@@ -3,12 +3,14 @@ require('dotenv').config()
 const nodeEnvValues = {
   apiClientId: process.env.API_CLIENT_ID || '',
   apiClientSecret: process.env.API_CLIENT_SECRET || '',
-  jobBoard: process.env.JOB_BOARD_DOMAIN || 'https://teammaker-jobs/'
+  testApiClientId: process.env.TEST_API_CLIENT_ID || '',
+  testApiClientSecret: process.env.TEST_API_CLIENT_SECRET || ''
 }
 
 // 以下がデフォルト値になる
 const baseValues = {
   apiDomain: 'http://localhost:8888',
+  jobBoard: 'http://localhost:5000',
   isMock: false
 }
 

--- a/constants/header-menu-items.ts
+++ b/constants/header-menu-items.ts
@@ -32,17 +32,17 @@ export const settingItems: MenuItem[]  = [
     text: 'ログイン申請',
     link: '/social-accounts',
     action: (): void => {}
-  },
-  {
-    text: 'LINE設定',
-    link: '/line',
-    action: (): void => {}
-  },
-  {
-    text: 'パスワード変更',
-    link: '/password',
-    action: (): void => {}
   }
+  // {
+  //   text: 'LINE設定',
+  //   link: '/line',
+  //   action: (): void => {}
+  // },
+  // {
+  //   text: 'パスワード変更',
+  //   link: '/password',
+  //   action: (): void => {}
+  // }
 ]
 
 export const accountItems: MenuItem[] = [

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,17 @@
+{
+  "hosting": {
+    "target": "admin",
+    "public": "dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -33,7 +33,7 @@
           <v-menu offset-y>
             <template v-slot:activator="{ on }">
               <v-btn icon v-on="on">
-                <v-icon>mdi-settings</v-icon>
+                <v-icon>mdi-cog-outline</v-icon>
               </v-btn>
             </template>
             <v-list>
@@ -47,9 +47,9 @@
             </v-list>
           </v-menu>
         </div>
-        <v-btn icon>
+        <!-- <v-btn icon>
           <v-icon>mdi-bell</v-icon>
-        </v-btn>
+        </v-btn> -->
         <div class="text-center">
           <v-menu offset-y>
             <template v-slot:activator="{ on }">

--- a/middleware/is-logged-in.ts
+++ b/middleware/is-logged-in.ts
@@ -31,7 +31,9 @@ const isLoggedIn: Middleware = (context: Context) => {
   }
 
   // ログイン後は、redirectToをクリアする
-  loginStore.clearRedirectTo()
+  if (loginStore.isLoggedIn) {
+    loginStore.clearRedirectTo()
+  }
 }
 
 export default isLoggedIn

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "stage": "cross-env NODE_ENV=\"staging\" nuxt",
     "build": "nuxt build",
     "build:mock": "cross-env NODE_ENV=\"mock\" nuxt build",
+    "build:stage": "cross-env NODE_ENV=\"staging\" nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
     "generate:mock": "cross-env NODE_ENV=\"mock\" nuxt generate",

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -4,7 +4,7 @@
       <v-alert type="error">{{ message }}</v-alert>
     </v-container>
     <v-container>
-      <v-text-field v-model="uniqueId" label="会社番号" />
+      <v-text-field v-model="uniqueId" label="会社コード" />
     </v-container>
     <v-divider />
     <v-container>

--- a/pages/login/redirect.vue
+++ b/pages/login/redirect.vue
@@ -7,8 +7,12 @@ import { Vue, Component } from 'nuxt-property-decorator'
 import { Context } from '@nuxt/types' // eslint-disable-line no-unused-vars
 import { loginStore } from '@/store'
 import { SocialLoginPost } from '@/constants/models/login/login-post'
+import DataLoading from '@/components/data-loading.vue'
 
-@Component({ middleware: ['initialize-form-data'] })
+@Component({
+  middleware: ['initialize-form-data'],
+  components: { DataLoading }
+})
 export default class RedirectLoginVue extends Vue {
   asyncData({ env, query }: Context) {
     return {

--- a/pages/social-accounts/index.vue
+++ b/pages/social-accounts/index.vue
@@ -10,7 +10,13 @@
             class="elevation-1"
           >
             <template v-slot:item.image="{ item }">
-              <v-img :src="item.image" aspect-ratio="2" contain></v-img>
+              <v-img
+                v-if="item.image"
+                :src="item.image"
+                aspect-ratio="2"
+                contain
+              />
+              <p v-else>No Image</p>
             </template>
             <template v-slot:item.status="{ item }">
               {{ item.user.is_valid ? '有効' : '無効' }}

--- a/plugins/persisted-state.js
+++ b/plugins/persisted-state.js
@@ -1,8 +1,8 @@
-import createPersistedState from 'vuex-persistedstate'
+import injectPersistedState from 'vuex-persistedstate'
 
 export default ({ store }) => {
   // sessionStorageに格納したい値を設定する
-  createPersistedState({
+  injectPersistedState({
     key: 'tm-app',
     storage: window.sessionStorage,
     paths: [
@@ -15,7 +15,7 @@ export default ({ store }) => {
 
   // localStorageに格納したい値を設定する
   // セキュリティの都合上、重要な情報は格納しない
-  createPersistedState({
+  injectPersistedState({
     key: 'tm-app-local',
     paths: ['login.redirectTo']
   })(store)


### PR DESCRIPTION
## 対応内容
### 全体
#### config周り
- 不要なconfigの削除
- firebase用の処理の修正
    - ignoreの追加
    - ステージングのURLを追加
- ステージングへのpush用コマンドの追加

#### UI周り
- 未実装の導線をコメントアウト
- 表示されないアイコンの修正
- 会社番号 → 会社コードに修正
- 読み込み処理の追加

### 広報画面
- 広報用URLの表示処理の実装
- シェア画面へ遷移可能に修正

### ログイン申請画面
- SNSアカウントに画像設定がない場合のバグを修正 