### PR TITLE
広報先を選択可能に修正

### DIFF
--- a/components/announces/announce-form.vue
+++ b/components/announces/announce-form.vue
@@ -3,20 +3,28 @@
     <v-container>
       <h2>LINEで広報する</h2>
       <v-stepper v-model="currentStep">
-        <v-stepper-header>
-          <v-divider></v-divider>
-          <v-stepper-step :complete="currentStep > 1" step="1">
-            広報文を入力する
-          </v-stepper-step>
-          <v-divider></v-divider>
-          <v-stepper-step :complete="currentStep > 2" step="2">
-            入力内容を確認して、LINEで広報する
-          </v-stepper-step>
-          <v-divider></v-divider>
-        </v-stepper-header>
+        <announce-step-header :current-step="currentStep" />
         <v-stepper-items>
-          <announce-input v-model="announce" @changeStep="changeStep" />
-          <announce-confirm v-model="announce" @changeStep="changeStep" />
+          <choose-channel
+            v-model="channels"
+            :job="job"
+            :step="1"
+            @changeStep="changeStep"
+          />
+          <announce-input
+            v-model="announce"
+            :channels="channels"
+            :step="2"
+            :job="job"
+            @changeStep="changeStep"
+          />
+          <announce-confirm
+            :channels="channels"
+            :announce="announce"
+            :job="job"
+            :step="3"
+            @changeStep="changeStep"
+          />
         </v-stepper-items>
       </v-stepper>
     </v-container>
@@ -24,13 +32,27 @@
 </template>
 
 <script>
-import announceInput from '@/components/announces/announce/announce-input.vue'
-import announceConfirm from '@/components/announces/announce/announce-confirm.vue'
+import announceConfirm from './announce/announce-confirm.vue'
+import announceInput from './announce/announce-input.vue'
+import announceStepHeader from './announce-steps/announce-step-header.vue'
+import chooseChannel from './announce/choose-channel.vue'
 
 export default {
-  components: { announceConfirm, announceInput },
+  components: {
+    announceConfirm,
+    announceInput,
+    announceStepHeader,
+    chooseChannel
+  },
+  props: {
+    job: {
+      type: Object,
+      default: null
+    }
+  },
   data: () => ({
     announce: '',
+    channels: [],
     currentStep: 1,
     dialog: false
   }),

--- a/components/announces/announce-steps/announce-step-header.vue
+++ b/components/announces/announce-steps/announce-step-header.vue
@@ -1,0 +1,28 @@
+<template>
+  <v-stepper-header>
+    <v-divider></v-divider>
+    <v-stepper-step :complete="currentStep > 1" step="1">
+      広報先を選択する
+    </v-stepper-step>
+    <v-divider></v-divider>
+    <v-stepper-step :complete="currentStep > 2" step="2">
+      広報文を入力する
+    </v-stepper-step>
+    <v-divider></v-divider>
+    <v-stepper-step :complete="currentStep > 3" step="3">
+      入力内容を確認して、LINEで広報する
+    </v-stepper-step>
+    <v-divider></v-divider>
+  </v-stepper-header>
+</template>
+
+<script>
+export default {
+  props: {
+    currentStep: {
+      type: Number,
+      required: true
+    }
+  }
+}
+</script>

--- a/components/announces/announce/announce-actions.vue
+++ b/components/announces/announce/announce-actions.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="text-right">
+    <v-btn :disabled="loading" color="primary" @click="doAnnounce">
+      送信する
+    </v-btn>
+    <v-btn text @click="changeBeforeStep">戻る</v-btn>
+    <v-dialog v-model="dialog" width="500">
+      <v-card class="py-8">
+        <v-card-title class="headline py-8" primary-title>
+          {{ announceResult }}
+        </v-card-title>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="primary" @click="clearDialog">
+            OK
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+import { postAnnounceError } from '@/constants/announces/announce.ts'
+
+export default {
+  props: {
+    announce: {
+      type: String,
+      required: true
+    },
+    channels: {
+      type: Array,
+      required: true
+    }
+  },
+  data: () => ({
+    announceResult: '',
+    loading: false
+  }),
+  computed: {
+    dialog() {
+      return this.announceResult !== ''
+    }
+  },
+  methods: {
+    clearDialog() {
+      this.announceResult = ''
+    },
+    changeBeforeStep() {
+      this.$emit('changeBeforeStep')
+    },
+    async doAnnounce() {
+      this.loading = true
+      try {
+        this.announceResult = await this.postAnnounce({
+          announce: this.announce,
+          channels: this.channels
+        })
+      } catch (error) {
+        this.announceResult = postAnnounceError
+      } finally {
+        this.loading = false
+      }
+    },
+    ...mapActions('announce', ['postAnnounce'])
+  }
+}
+</script>

--- a/components/announces/announce/announce-input.vue
+++ b/components/announces/announce/announce-input.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-stepper-content step="1">
-    <h3 class="py-3">社員へ送信する広報文を入力しましょう。</h3>
+  <v-stepper-content step="2">
+    <h3 class="py-3">社員へ送信する広報文を入力してください。</h3>
     <h4 class="py-1">広報文</h4>
     <v-row justify="center">
       <v-col :lg="9">
@@ -18,7 +18,7 @@
         <v-form ref="leadForm" v-model="valid">
           <v-textarea
             v-model="announce"
-            :rules="announceRequired"
+            :rules="[(value) => !!value || '広報文を入力してください。']"
             auto-grow
             autofocus
             rows="7"
@@ -28,20 +28,23 @@
         </v-form>
       </v-col>
     </v-row>
-    <job-confirm />
+    <job-confirm :job="job" />
     <div class="text-right">
       <v-btn color="primary" justify-end :disabled="!valid" @click="changeStep">
         次へ
       </v-btn>
+      <v-btn text @click="changeBeforeStep">戻る</v-btn>
     </div>
   </v-stepper-content>
 </template>
 
 <script>
 import jobConfirm from '../job-confirm.vue'
+import announceStepMixin from './announce-step-mixin.js'
 
 export default {
   components: { jobConfirm },
+  mixins: [announceStepMixin],
   props: {
     value: {
       type: String,
@@ -49,8 +52,7 @@ export default {
     }
   },
   data: () => ({
-    valid: false,
-    announceRequired: [(announce) => !!announce || '広報文を入力してください。']
+    valid: false
   }),
   computed: {
     announce: {
@@ -60,11 +62,6 @@ export default {
       set(lead) {
         this.$emit('input', lead)
       }
-    }
-  },
-  methods: {
-    changeStep() {
-      this.$emit('changeStep', 2)
     }
   }
 }

--- a/components/announces/announce/announce-step-mixin.js
+++ b/components/announces/announce/announce-step-mixin.js
@@ -1,0 +1,20 @@
+export default {
+  props: {
+    step: {
+      type: Number,
+      required: true
+    },
+    job: {
+      type: Object,
+      default: null
+    }
+  },
+  methods: {
+    changeStep() {
+      this.$emit('changeStep', this.step + 1)
+    },
+    changeBeforeStep() {
+      this.$emit('changeStep', this.step - 1)
+    }
+  }
+}

--- a/components/announces/announce/choose-channel.vue
+++ b/components/announces/announce/choose-channel.vue
@@ -1,0 +1,94 @@
+<template>
+  <v-stepper-content step="1">
+    <h3 class="py-3">広報先を選択してください。</h3>
+    <h4 class="py-1">広報先を選ぶ</h4>
+    <v-form ref="channelForm" v-model="isValid">
+      <v-container class="ml-2">
+        <v-row>
+          <v-checkbox v-model="checkAll" label="すべてを選択する" />
+        </v-row>
+        <v-row v-for="channel in channels" :key="channel.id">
+          <v-checkbox
+            v-model="chooseChannels"
+            :label="channel.name"
+            :value="channel"
+            :rules="[validateChooseChannels]"
+            :disabled="job ? !channel.is_internal : false"
+            :hint="
+              job && !channel.is_internal
+                ? '求人を広報する場合、社外広報は選択できません。'
+                : ''
+            "
+            persistent-hint
+          />
+        </v-row>
+        <div class="text-right">
+          <v-btn
+            color="primary"
+            justify-end
+            :disabled="!isValid"
+            @click="changeStep"
+          >
+            次へ
+          </v-btn>
+        </div>
+      </v-container>
+    </v-form>
+  </v-stepper-content>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import announceStepMixin from './announce-step-mixin.js'
+
+export default {
+  mixins: [announceStepMixin],
+  props: {
+    value: {
+      type: Array,
+      required: true
+    }
+  },
+  data: () => ({
+    isValid: false
+  }),
+  computed: {
+    checkAll: {
+      get() {
+        return this.chooseChannels.length === this.filteredChannel.length
+      },
+      set(checked) {
+        if (checked) {
+          this.chooseChannels = this.filteredChannel
+        } else {
+          this.chooseChannels = []
+        }
+      }
+    },
+    filteredChannel() {
+      if (!this.job) {
+        return this.channels
+      }
+      return this.channels.filter((channel) => channel.is_internal)
+    },
+    chooseChannels: {
+      get() {
+        return this.value
+      },
+      set(channels) {
+        this.$emit('input', channels)
+      }
+    },
+    ...mapState('announce', ['channels'])
+  },
+  methods: {
+    validateChooseChannels() {
+      if (this.chooseChannels.length === 0) {
+        return '最低でも、一つの広報先を選択してください。'
+      }
+
+      return true
+    }
+  }
+}
+</script>

--- a/components/announces/job-confirm.vue
+++ b/components/announces/job-confirm.vue
@@ -24,10 +24,16 @@
 </template>
 
 <script>
-import { mapGetters, mapState } from 'vuex'
 import { jobHeaders } from '@/constants/jobs/jobs'
+import { getAnnounceUrl } from '@/constants/announces/models.ts'
 
 export default {
+  props: {
+    job: {
+      type: Object,
+      default: null
+    }
+  },
   computed: {
     headers() {
       return jobHeaders
@@ -36,8 +42,9 @@ export default {
     jobs() {
       return [this.job]
     },
-    ...mapGetters('announce', ['announceUrl']),
-    ...mapState('announce', ['job'])
+    announceUrl() {
+      return getAnnounceUrl(this.job)
+    }
   }
 }
 </script>

--- a/components/jobs/job-footer.vue
+++ b/components/jobs/job-footer.vue
@@ -3,26 +3,26 @@
     <v-card flat tile width="100%" class="blue-grey lighten-5">
       <v-card-text>
         <div class="d-flex justify-end pb-5">
-          <v-btn x-large color="primary" outlined class="mx-2" to="/jobs">
-            キャンセル
-          </v-btn>
           <v-btn
-            x-large
             color="primary"
-            outlined
             class="mx-2"
+            x-large
             @click="doUpsertJob(upsertJobInput)"
           >
             保存する
           </v-btn>
           <v-btn
             v-if="canUpdate"
-            x-large
             color="primary"
             class="mx-2"
+            outlined
+            x-large
             @click="changePublish(upsertJobInput)"
           >
             {{ isPublished ? '下書きに戻す' : '公開する' }}
+          </v-btn>
+          <v-btn x-large color="primary" outlined class="mx-2" to="/jobs">
+            キャンセル
           </v-btn>
         </div>
       </v-card-text>

--- a/constants/announces/announce.ts
+++ b/constants/announces/announce.ts
@@ -1,5 +1,8 @@
 import gql from 'graphql-tag'
 
+export const postAnnounceError = `広報文の送信に失敗いたしました。
+お手数ですが、管理部まで問い合わせてくださいませ。`
+
 export const createAnnounce = gql`
   mutation($input: CreateAnnounceInput!) {
     createAnnounce(input: $input) {
@@ -28,6 +31,16 @@ export const getJob = gql`
         isPublished
         publishState
       }
+    }
+  }
+`
+
+export const getChannels = gql`
+  query {
+    channels {
+      id
+      name
+      is_internal
     }
   }
 `

--- a/constants/announces/models.ts
+++ b/constants/announces/models.ts
@@ -1,0 +1,54 @@
+import { loginStore } from '@/store'
+
+export interface Channel {
+  id: string
+  name: string
+}
+
+interface Page {
+  slug: string
+  isPublished: boolean
+  publishState: string
+}
+
+export interface AnnounceInput {
+  announce: string
+  channels: Channel[]
+}
+
+export interface Job {
+  id: string
+  code: string
+  name: string
+  last_announced_at: string
+  page: Page
+}
+
+export const getCreateAnnounceInput = (
+  announce: string,
+  channels: Channel[],
+  jobId: string
+) => {
+  const channelCreates = channels.map((channel) => ({ channel_id: channel.id }))
+  return {
+    content: announce,
+    job_id: jobId,
+    channelNotifications: {
+      create: channelCreates
+    }
+  }
+}
+
+
+export const getAnnounceUrl = (job: Job) => {
+  if (job) {
+    const domain = window.location.origin
+
+    const reqirectTo = `/share/jobs/${job.id}`
+    return `${domain}/login/?unique_id=${
+      loginStore.uniqueId
+    }&redirect_to=${encodeURIComponent(reqirectTo)}`
+  }
+
+  return ''
+}

--- a/pages/announces/create.vue
+++ b/pages/announces/create.vue
@@ -1,25 +1,30 @@
 <template>
-  <announce-form />
+  <announce-form :job="jobValue" />
 </template>
 
 <script>
 import { mapMutations } from 'vuex'
-import { getJob } from '@/constants/announce/announce'
+import { getChannels, getJob } from '@/constants/announces/announce.ts'
 import announceForm from '@/components/announces/announce-form.vue'
 
 export default {
   watchQuery: ['jobId'],
   components: { announceForm },
+  data: () => ({ jobValue: null }),
   asyncData({ query, store }) {
     const jobId = 'jobId' in query ? query.jobId : null
-    store.commit('announce/clearJob')
-
     return { jobId }
   },
   methods: {
-    ...mapMutations('announce', ['setJob'])
+    ...mapMutations('announce', ['setChannels'])
   },
   apollo: {
+    channels: {
+      query: getChannels,
+      result({ data }) {
+        this.setChannels(data.channels)
+      }
+    },
     job: {
       query: getJob,
       variables() {
@@ -31,7 +36,7 @@ export default {
         return this.jobId === null
       },
       result({ data }) {
-        this.setJob(data.job)
+        this.jobValue = data.job
       }
     }
   }

--- a/store/announce.ts
+++ b/store/announce.ts
@@ -1,75 +1,38 @@
 import { Action, Mutation, Module, VuexModule } from 'vuex-module-decorators'
 import { apolloMutate } from '@/plugins/apollo/get-apollo-client'
-import { createAnnounce } from '@/constants/announce/announce'
-import { loginStore } from '@/store'
-
-interface Page {
-  slug: string
-  isPublished: boolean
-  publishState: string
-}
-
-export interface Job {
-  id: string
-  code: string
-  name: string
-  last_announced_at: string
-  page: Page
-}
+import { createAnnounce } from '~/constants/announces/announce'
+import { Channel, Job, AnnounceInput, getCreateAnnounceInput } from '~/constants/announces/models'
 
 interface AnnounceState {
   jobId: string | null
   job: Job | null
+  channels: Channel[]
 }
-
-const getCreateAnnounceInput = (announce: string, jobId: string) => ({
-  content: announce,
-  job_id: jobId,
-  channelNotifications: {
-    create: [{
-      channel_id: 1
-    }]
-  }
-})
 
 @Module({ stateFactory: true, namespaced: true, name: 'announce' })
 export default class Announce extends VuexModule implements AnnounceState {
   job: Job | null = null
+  channels: Channel[] = []
 
   get jobId(): string {
     return this.job ? this.job.id : ''
   }
 
-  get announceUrl(): string {
-    if (this.job) {
-      const domain: string = window.location.origin
-      const unique_id: string = loginStore.uniqueId
-
-      const reqirectTo: string = `/share/jobs/${this.job.id}`
-      return `${domain}/login/?unique_id=${unique_id}&redirect_to=${encodeURIComponent(
-        reqirectTo
-      )}`
-    }
-
-    return ''
-  }
-
   @Mutation
-  setJob(job: Job) {
-    this.job = job
-  }
-
-  @Mutation
-  clearJob() {
-    this.job = null
+  setChannels(channels: Channel[]) {
+    this.channels = channels
   }
 
   @Action({ rawError: true })
-  async postAnnounce(announce: string) {
+  async postAnnounce({ announce, channels }: AnnounceInput) {
     await apolloMutate({
       mutation: createAnnounce,
       variables: {
-        input: getCreateAnnounceInput(announce, this.jobId)
+        input: getCreateAnnounceInput(
+          announce,
+          channels,
+          this.jobId
+        )
       }
     })
     return '広報文の送信に成功いたしました。'


### PR DESCRIPTION
## 対応内容
- 広報先の選択コンポーネントの追加
- 各種リファクタリング
    - 既存コンポーネントの分割
    - 求人をpropsに変更
    - 定数ファイルの分割
    - 共通処理のmixin化