### PR TITLE
求人票を作成できないバグの修正

### DIFF
--- a/components/jobs/job-detail-mixins.js
+++ b/components/jobs/job-detail-mixins.js
@@ -5,7 +5,7 @@ import jobFooter from './job-footer.vue'
 export default {
   components: { jobForm, jobFooter },
   data: () => ({
-    jobValue: {}
+    jobValue: { page: { content: null } }
   }),
   apollo: {
     employmentCategories: {

--- a/components/jobs/job-form.vue
+++ b/components/jobs/job-form.vue
@@ -16,7 +16,7 @@
                 <v-icon v-if="doEditImage" color="primary" @click="doEditImage = false">
                   mdi-close
                 </v-icon>
-                <v-icon v-else color="primary" @click="doEditImage = true">
+                <v-icon v-else-if="headerImageUrl" color="primary" @click="doEditImage = true">
                   mdi-pencil
                 </v-icon>
               </div>


### PR DESCRIPTION
## 対応内容
- 求人票の初期値を修正
- ヘッダー画像が登録されていない場合、キャンセルボタンを表示しないようにする